### PR TITLE
add Filterable1 instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - `Monad`
 - `Alternative`
+- `Filterable`
 
 # Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,7 +293,8 @@
     "fp-ts": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.14.3.tgz",
-      "integrity": "sha512-tAnefu8QCuPaUaEywmhzpBWbRq2NRcailU5gtV2O09+xXVnJMBIyJi4qXy2fMlhMFsebDqUPpgoHpSErs94HTg=="
+      "integrity": "sha512-tAnefu8QCuPaUaEywmhzpBWbRq2NRcailU5gtV2O09+xXVnJMBIyJi4qXy2fMlhMFsebDqUPpgoHpSErs94HTg==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,9 +291,9 @@
       }
     },
     "fp-ts": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.5.0.tgz",
-      "integrity": "sha512-4eWgPeuZleinnN14/Ce8GrD+3Rgp+TYIl20IFP0rHFwB7IRoZfBAM5q8Iia8fRpJPFoOpWNoN9Jn7wn4tQOD0Q=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.14.3.tgz",
+      "integrity": "sha512-tAnefu8QCuPaUaEywmhzpBWbRq2NRcailU5gtV2O09+xXVnJMBIyJi4qXy2fMlhMFsebDqUPpgoHpSErs94HTg=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/gcanti/fp-ts-rxjs",
   "dependencies": {
-    "fp-ts": "^1.0.1",
+    "fp-ts": "^1.14.3",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,18 +26,21 @@
   },
   "homepage": "https://github.com/gcanti/fp-ts-rxjs",
   "dependencies": {
-    "fp-ts": "^1.14.3",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {
     "@types/mocha": "2.2.38",
     "@types/node": "7.0.4",
+    "fp-ts": "^1.14.3",
     "mocha": "^5.2.0",
     "prettier": "^1.14.3",
     "ts-node": "3.2.0",
     "tslint": "4.4.2",
     "tslint-config-standard": "4.0.0",
     "typescript": "^3.1.3"
+  },
+  "peerDependencies": {
+    "fp-ts": "^1.7.0"
   },
   "tags": [
     "fp-ts",

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -2,12 +2,12 @@ import { Alternative1 } from 'fp-ts/lib/Alternative'
 import { Monad1 } from 'fp-ts/lib/Monad'
 import { Monoid } from 'fp-ts/lib/Monoid'
 import { combineLatest, EMPTY, merge, Observable, of as rxOf } from 'rxjs'
-import { map as rxMap, mergeMap, filter as rxFilter } from 'rxjs/operators'
+import { map as rxMap, mergeMap } from 'rxjs/operators'
 import { Filterable1 } from 'fp-ts/lib/Filterable'
 import { Either, fromPredicate as eitherFromPredicate } from 'fp-ts/lib/Either'
 import { Separated } from 'fp-ts/lib/Compactable'
 import { Predicate, identity } from 'fp-ts/lib/function'
-import { Option, fromPredicate as optionFromPredicate, some, none, Some } from 'fp-ts/lib/Option'
+import { Option, fromPredicate as optionFromPredicate, some, none } from 'fp-ts/lib/Option'
 
 declare module 'rxjs/internal/Observable' {
   interface Observable<T> {
@@ -47,11 +47,7 @@ const alt = <A>(x: Observable<A>, y: Observable<A>): Observable<A> => merge(x, y
 const zero = <A>(): Observable<A> => EMPTY
 
 function filterMap<A, B>(fa: Observable<A>, f: (a: A) => Option<B>): Observable<B> {
-  return fa.pipe(
-    rxMap(f),
-    rxFilter((b): b is Some<B> => b.isSome()),
-    rxMap(v => v.value)
-  )
+  return fa.pipe(mergeMap(a => f(a).fold(zero(), of)))
 }
 
 const compact: <A>(fa: Observable<Option<A>>) => Observable<A> = fa => filterMap(fa, identity)

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -2,7 +2,12 @@ import { Alternative1 } from 'fp-ts/lib/Alternative'
 import { Monad1 } from 'fp-ts/lib/Monad'
 import { Monoid } from 'fp-ts/lib/Monoid'
 import { combineLatest, EMPTY, merge, Observable, of as rxOf } from 'rxjs'
-import { map as rxMap, mergeMap } from 'rxjs/operators'
+import { map as rxMap, mergeMap, filter as rxFilter } from 'rxjs/operators'
+import { Filterable1 } from 'fp-ts/lib/Filterable'
+import { Either, fromPredicate as eitherFromPredicate } from 'fp-ts/lib/Either'
+import { Separated } from 'fp-ts/lib/Compactable'
+import { Predicate, identity } from 'fp-ts/lib/function'
+import { Option, fromPredicate as optionFromPredicate, some, none, Some } from 'fp-ts/lib/Option'
 
 declare module 'rxjs/internal/Observable' {
   interface Observable<T> {
@@ -41,12 +46,47 @@ const alt = <A>(x: Observable<A>, y: Observable<A>): Observable<A> => merge(x, y
 
 const zero = <A>(): Observable<A> => EMPTY
 
-export const observable: Monad1<URI> & Alternative1<URI> = {
+function filterMap<A, B>(fa: Observable<A>, f: (a: A) => Option<B>): Observable<B> {
+  return fa.pipe(
+    rxMap(f),
+    rxFilter((b): b is Some<B> => b.isSome()),
+    rxMap(v => v.value)
+  )
+}
+
+const compact: <A>(fa: Observable<Option<A>>) => Observable<A> = fa => filterMap(fa, identity)
+
+const filter: <A>(fa: Observable<A>, p: Predicate<A>) => Observable<A> = (fa, p) =>
+  filterMap(fa, optionFromPredicate(p))
+
+function partitionMap<RL, RR, A>(
+  fa: Observable<A>,
+  f: (a: A) => Either<RL, RR>
+): Separated<Observable<RL>, Observable<RR>> {
+  return {
+    left: filterMap(fa, a => f(a).fold(some, () => none)),
+    right: filterMap(fa, a => f(a).fold(() => none, some))
+  }
+}
+
+const separate: <A, B>(fa: Observable<Either<A, B>>) => Separated<Observable<A>, Observable<B>> = fa =>
+  partitionMap(fa, identity)
+
+const partition: <A>(fa: Observable<A>, p: Predicate<A>) => Separated<Observable<A>, Observable<A>> = (fa, p) =>
+  partitionMap(fa, eitherFromPredicate(p, identity))
+
+export const observable: Monad1<URI> & Alternative1<URI> & Filterable1<URI> = {
   URI,
   map,
   of,
   ap,
   chain,
   zero,
-  alt
+  alt,
+  compact,
+  separate,
+  partitionMap,
+  partition,
+  filterMap,
+  filter
 }

--- a/test/Observable.ts
+++ b/test/Observable.ts
@@ -14,7 +14,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [1])
+        assert.deepStrictEqual(events, [1])
       })
   })
 
@@ -26,7 +26,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [2, 4, 6])
+        assert.deepStrictEqual(events, [2, 4, 6])
       })
   })
 
@@ -40,7 +40,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [3, 6, 9])
+        assert.deepStrictEqual(events, [3, 6, 9])
       })
   })
 
@@ -51,7 +51,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [1, 2, 2, 3, 3, 4])
+        assert.deepStrictEqual(events, [1, 2, 2, 3, 3, 4])
       })
   })
 
@@ -62,7 +62,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [2, 3])
+        assert.deepStrictEqual(events, [2, 3])
       })
   })
 
@@ -73,7 +73,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [2, 3])
+        assert.deepStrictEqual(events, [2, 3])
       })
   })
 
@@ -84,7 +84,7 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [2, 3])
+        assert.deepStrictEqual(events, [2, 3])
       })
   })
 
@@ -95,14 +95,14 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [1])
+        assert.deepStrictEqual(events, [1])
       })
       .then(() =>
         s.right
           .pipe(bufferTime(10))
           .toPromise()
           .then(events => {
-            assert.deepEqual(events, [2, 3])
+            assert.deepStrictEqual(events, [2, 3])
           })
       )
   })
@@ -114,14 +114,14 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [1])
+        assert.deepStrictEqual(events, [1])
       })
       .then(() =>
         s.right
           .pipe(bufferTime(10))
           .toPromise()
           .then(events => {
-            assert.deepEqual(events, [2, 3])
+            assert.deepStrictEqual(events, [2, 3])
           })
       )
   })
@@ -133,14 +133,14 @@ describe('Observable', () => {
       .pipe(bufferTime(10))
       .toPromise()
       .then(events => {
-        assert.deepEqual(events, [1])
+        assert.deepStrictEqual(events, [1])
       })
       .then(() =>
         s.right
           .pipe(bufferTime(10))
           .toPromise()
           .then(events => {
-            assert.deepEqual(events, [2, 3])
+            assert.deepStrictEqual(events, [2, 3])
           })
       )
   })


### PR DESCRIPTION
~~second commit "switchMap instead of mergeMap for chain" is unrelated and completely arbitrary (just found `switchMap` to be what I want in all cases), and can be removed~~ edit: removed since breaking and not sure if `switchMap` is actually respecting the monad laws

~same goes for "align export to be similar to fp-ts/lib ones", was there a particular reason?~ edit: removed this commit, it made no sense