### PR TITLE
feat: adds ReaderObservableEither and StateReaderObservableEither

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2279,9 +2279,9 @@
       }
     },
     "fp-ts": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.3.tgz",
-      "integrity": "sha512-R/QwlxnRlboZIObqKjOUf8rkXz36uSWfJO2M5o2cqf7UiHoHlNMojr/PiUyj8j3l1fOP62dR6nsKvFaRSJBIaQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.4.tgz",
+      "integrity": "sha512-J5wFa/BzT57A+DIvwAYS5LTsbRiXsvF9hsefP3ZfzsHLuWGjtHAheG1WscG1tX3og1PDZyv6mZAUTlpH1MmHhA==",
       "dev": true
     },
     "fragment-cache": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/gcanti/fp-ts-rxjs",
   "peerDependencies": {
-    "fp-ts": "^2.4.3",
+    "fp-ts": "^2.4.4",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/mocha": "2.2.38",
     "@types/node": "7.0.4",
     "docs-ts": "^0.3.4",
-    "fp-ts": "^2.4.3",
+    "fp-ts": "^2.4.4",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",
     "mocha": "^5.2.0",

--- a/src/MonadObservable.ts
+++ b/src/MonadObservable.ts
@@ -3,8 +3,16 @@
  *
  * @since 0.6.6
  */
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
-import { MonadTask, MonadTask1, MonadTask2, MonadTask2C, MonadTask3, MonadTask3C } from 'fp-ts/lib/MonadTask'
+import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from 'fp-ts/lib/HKT'
+import {
+  MonadTask,
+  MonadTask1,
+  MonadTask2,
+  MonadTask2C,
+  MonadTask3,
+  MonadTask3C,
+  MonadTask4
+} from 'fp-ts/lib/MonadTask'
 import { Observable } from 'rxjs'
 
 /**
@@ -43,8 +51,15 @@ export interface MonadObservable3<M extends URIS3> extends MonadTask3<M> {
 }
 
 /**
- * @since 2.2.0
+ * @since 0.6.6
  */
 export interface MonadObservable3C<M extends URIS3, E> extends MonadTask3C<M, E> {
   readonly fromObservable: <R, A>(fa: Observable<A>) => Kind3<M, R, E, A>
+}
+
+/**
+ * @since 0.6.7
+ */
+export interface MonadObservable4<M extends URIS4> extends MonadTask4<M> {
+  readonly fromObservable: <S, R, E, A>(fa: Observable<A>) => Kind4<M, S, R, E, A>
 }

--- a/src/ReaderObservableEither.ts
+++ b/src/ReaderObservableEither.ts
@@ -1,0 +1,196 @@
+/**
+ * @since 0.6.10
+ */
+import * as OBE from './ObservableEither'
+import { io as IO, reader as R, task as T } from 'fp-ts'
+import { MonadObservable3 } from './MonadObservable'
+import { MonadThrow3 } from 'fp-ts/lib/MonadThrow'
+import { Bifunctor3 } from 'fp-ts/lib/Bifunctor'
+import { getReaderM } from 'fp-ts/lib/ReaderT'
+import { pipeable } from 'fp-ts/lib/pipeable'
+import { Observable } from 'rxjs'
+
+/**
+ * @since 0.6.10
+ */
+export const URI = 'ReaderObservableEither'
+
+/**
+ * @since 0.6.10
+ */
+export type URI = typeof URI
+
+/**
+ * @since 0.6.10
+ */
+export interface ReaderObservableEither<R, E, A> {
+  (r: R): OBE.ObservableEither<E, A>
+}
+
+declare module 'fp-ts/lib/HKT' {
+  export interface URItoKind3<R, E, A> {
+    readonly [URI]: ReaderObservableEither<R, E, A>
+  }
+}
+
+const M = getReaderM(OBE.observableEither)
+
+/**
+ * @since 0.6.10
+ */
+export function ask<R, E>(): ReaderObservableEither<R, E, R> {
+  return M.ask<R, E>()
+}
+
+/**
+ * @since 0.6.10
+ */
+export function asks<R, E, A>(f: (r: R) => A): ReaderObservableEither<R, E, A> {
+  return M.asks<R, E, A>(f)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromObservableEither<R, E, A>(ma: OBE.ObservableEither<E, A>): ReaderObservableEither<R, E, A> {
+  return M.fromM(ma)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromReader<R, E, A>(ma: R.Reader<R, A>): ReaderObservableEither<R, E, A> {
+  return M.fromReader(ma)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function local<R, Q>(
+  f: (d: Q) => R
+): <E, A>(ma: ReaderObservableEither<R, E, A>) => ReaderObservableEither<Q, E, A> {
+  return ma => M.local(ma, f)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function of<R, E, A>(a: A): ReaderObservableEither<R, E, A> {
+  return M.of(a)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromIO<R, E, A>(a: IO.IO<A>): ReaderObservableEither<R, E, A> {
+  return () => OBE.observableEither.fromIO(a)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromTask<R, E, A>(a: T.Task<A>): ReaderObservableEither<R, E, A> {
+  return () => OBE.observableEither.fromTask(a)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromObservable<R, E, A>(a: Observable<A>): ReaderObservableEither<R, E, A> {
+  return () => OBE.observableEither.fromObservable(a)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function throwError<R, E, A>(e: E): ReaderObservableEither<R, E, A> {
+  return () => OBE.left<E, A>(e)
+}
+
+/**
+ * @since 0.6.10
+ */
+export const readerObservableEither: MonadObservable3<URI> & MonadThrow3<URI> & Bifunctor3<URI> = {
+  URI,
+  ap: M.ap,
+  map: M.map,
+  of: M.of,
+  chain: M.chain,
+  fromIO,
+  fromObservable,
+  fromTask,
+  throwError,
+  bimap: (fea, f, g) => r => OBE.bimap(f, g)(fea(r)),
+  mapLeft: (fea, f) => r => OBE.mapLeft(f)(fea(r))
+}
+
+const {
+  ap,
+  apFirst,
+  apSecond,
+  bimap,
+  chain,
+  chainFirst,
+  filterOrElse,
+  flatten,
+  fromEither,
+  fromOption,
+  fromPredicate,
+  map,
+  mapLeft
+} = pipeable(readerObservableEither)
+
+export {
+  /**
+   * @since 0.6.10
+   */
+  ap,
+  /**
+   * @since 0.6.10
+   */
+  apFirst,
+  /**
+   * @since 0.6.10
+   */
+  apSecond,
+  /**
+   * @since 0.6.10
+   */
+  bimap,
+  /**
+   * @since 0.6.10
+   */
+  chain,
+  /**
+   * @since 0.6.10
+   */
+  chainFirst,
+  /**
+   * @since 0.6.10
+   */
+  filterOrElse,
+  /**
+   * @since 0.6.10
+   */
+  flatten,
+  /**
+   * @since 0.6.10
+   */
+  fromEither,
+  /**
+   * @since 0.6.10
+   */
+  fromOption,
+  /**
+   * @since 0.6.10
+   */
+  fromPredicate,
+  /**
+   * @since 0.6.10
+   */
+  map,
+  /**
+   * @since 0.6.10
+   */
+  mapLeft
+}

--- a/src/StateReaderObservableEither.ts
+++ b/src/StateReaderObservableEither.ts
@@ -1,0 +1,219 @@
+/**
+ * @since 0.6.10
+ */
+import { either as E, io as IO, task as T } from 'fp-ts'
+import { Bifunctor4 } from 'fp-ts/lib/Bifunctor'
+import { MonadThrow4 } from 'fp-ts/lib/MonadThrow'
+import { pipeable, pipe } from 'fp-ts/lib/pipeable'
+import { getStateM } from 'fp-ts/lib/StateT'
+import { Observable } from 'rxjs'
+import { MonadObservable4 } from './MonadObservable'
+import * as OB from './Observable'
+import * as ROBE from './ReaderObservableEither'
+
+/**
+ * @since 0.6.10
+ */
+export const URI = 'StateReaderObservableEither'
+
+/**
+ * @since 0.6.10
+ */
+export type URI = typeof URI
+
+/**
+ * @since 0.6.10
+ */
+export interface StateReaderObservableEither<S, R, E, A> {
+  (s: S): ROBE.ReaderObservableEither<R, E, [A, S]>
+}
+
+declare module 'fp-ts/lib/HKT' {
+  export interface URItoKind4<S, R, E, A> {
+    readonly [URI]: StateReaderObservableEither<S, R, E, A>
+  }
+}
+
+const M = getStateM(ROBE.readerObservableEither)
+
+/**
+ * @since 0.6.10
+ */
+
+/**
+ * @since 0.6.10
+ */
+export function evaluate<S>(
+  s: S
+): <R, E, A>(fa: StateReaderObservableEither<S, R, E, A>) => ROBE.ReaderObservableEither<R, E, A> {
+  return fa => M.evalState(fa, s)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function execute<S>(
+  s: S
+): <R, E, A>(fa: StateReaderObservableEither<S, R, E, A>) => ROBE.ReaderObservableEither<R, E, S> {
+  return fa => M.execState(fa, s)
+}
+
+/**
+ * @since 0.6.10
+ */
+export const fromReaderObservableEither: <S, R, E, A>(
+  ma: ROBE.ReaderObservableEither<R, E, A>
+) => StateReaderObservableEither<S, R, E, A> = M.fromM
+
+/**
+ * @since 0.6.10
+ */
+export const get: <R, E, S>() => StateReaderObservableEither<S, R, E, S> = M.get
+
+/**
+ * @since 0.6.10
+ */
+export const gets: <S, R, E, A>(f: (s: S) => A) => StateReaderObservableEither<S, R, E, A> = M.gets
+
+/**
+ * @since 0.6.10
+ */
+export const modify: <R, E, S>(f: (s: S) => S) => StateReaderObservableEither<S, R, E, void> = M.modify
+
+/**
+ * @since 0.6.10
+ */
+export const put: <R, E, S>(s: S) => StateReaderObservableEither<S, R, E, void> = M.put
+
+/**
+ * @since 0.6.10
+ */
+export const right: <S, R, E = never, A = never>(a: A) => StateReaderObservableEither<S, R, E, A> = M.of
+
+/**
+ * @since 0.6.10
+ */
+export const left: <S, R, E = never, A = never>(e: E) => StateReaderObservableEither<S, R, E, A> = throwError
+
+/**
+ * @since 0.6.10
+ */
+export function throwError<S, R, E, A>(e: E): StateReaderObservableEither<S, R, E, A> {
+  return () => ROBE.throwError(e)
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromIO<S, R, E, A>(io: IO.IO<A>): StateReaderObservableEither<S, R, E, A> {
+  return fromObservable(OB.fromIO(io))
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromTask<S, R, E, A>(task: T.Task<A>): StateReaderObservableEither<S, R, E, A> {
+  return fromObservable(OB.fromTask(task))
+}
+
+/**
+ * @since 0.6.10
+ */
+export function fromObservable<S, R, E, A>(observable: Observable<A>): StateReaderObservableEither<S, R, E, A> {
+  return s => () =>
+    pipe(
+      observable,
+      OB.map(a => E.right([a, s]))
+    )
+}
+
+/**
+ * @since 0.6.10
+ */
+export const stateReaderObservableEither: MonadObservable4<URI> & Bifunctor4<URI> & MonadThrow4<URI> = {
+  URI,
+  ap: M.ap,
+  chain: M.chain,
+  map: M.map,
+  of: M.of,
+  mapLeft: (fa, f) => s => pipe(fa(s), ROBE.mapLeft(f)),
+  bimap: (fea, f, g) => stateReaderObservableEither.mapLeft(M.map(fea, g), f),
+  throwError,
+  fromIO,
+  fromObservable,
+  fromTask
+}
+
+/**
+ * @since 0.6.10
+ */
+const {
+  ap,
+  apFirst,
+  apSecond,
+  bimap,
+  chain,
+  chainFirst,
+  filterOrElse,
+  flatten,
+  fromEither,
+  fromOption,
+  fromPredicate,
+  map,
+  mapLeft
+} = pipeable(stateReaderObservableEither)
+
+export {
+  /**
+   * @since 0.6.10
+   */
+  ap,
+  /**
+   * @since 0.6.10
+   */
+  apFirst,
+  /**
+   * @since 0.6.10
+   */
+  apSecond,
+  /**
+   * @since 0.6.10
+   */
+  bimap,
+  /**
+   * @since 0.6.10
+   */
+  chain,
+  /**
+   * @since 0.6.10
+   */
+  chainFirst,
+  /**
+   * @since 0.6.10
+   */
+  filterOrElse,
+  /**
+   * @since 0.6.10
+   */
+  flatten,
+  /**
+   * @since 0.6.10
+   */
+  fromEither,
+  /**
+   * @since 0.6.10
+   */
+  fromOption,
+  /**
+   * @since 0.6.10
+   */
+  fromPredicate,
+  /**
+   * @since 0.6.10
+   */
+  map,
+  /**
+   * @since 0.6.10
+   */
+  mapLeft
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as observable from './Observable'
 import * as readerObservable from './ReaderObservable'
 import * as observableEither from './ObservableEither'
 import * as readerObservableEither from './ReaderObservableEither'
+import * as stateReaderObservableEither from './StateReaderObservableEither'
 
 export {
   /**
@@ -22,5 +23,9 @@ export {
   /**
    * @since 0.6.10
    */
-  readerObservableEither
+  readerObservableEither,
+  /**
+   * @since 0.6.10
+   */
+  stateReaderObservableEither
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import * as observable from './Observable'
 import * as readerObservable from './ReaderObservable'
 import * as observableEither from './ObservableEither'
+import * as readerObservableEither from './ReaderObservableEither'
 
 export {
   /**
@@ -17,5 +18,9 @@ export {
   /**
    * @since 0.6.8
    */
-  observableEither
+  observableEither,
+  /**
+   * @since 0.6.10
+   */
+  readerObservableEither
 }

--- a/test/ReaderObservableEither.ts
+++ b/test/ReaderObservableEither.ts
@@ -1,0 +1,128 @@
+import * as assert from 'assert'
+import { either as E, io as IO, reader as R, task as T } from 'fp-ts'
+import { flow } from 'fp-ts/lib/function'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { bufferTime } from 'rxjs/operators'
+import { observable as OB, observableEither as OBE, readerObservableEither as ROBE } from '../src'
+
+// test helper to dry up LOC.
+const buffer = flow(R.map(bufferTime(10)), R.map(OB.toTask))
+
+describe('ReaderObservable', () => {
+  it('map', async () => {
+    const double = (n: number): number => n * 2
+
+    const robe = pipe(ROBE.of(3), ROBE.map(double), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(6)])
+  })
+
+  it('ap', async () => {
+    const double = (n: number): number => n * 2
+    const mab = ROBE.of(double)
+    const ma = ROBE.of(1)
+    const robe = pipe(mab, ROBE.ap(ma), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(2)])
+  })
+
+  it('chain', async () => {
+    const f = (a: string) => ROBE.of(a.length)
+    const robe = pipe(ROBE.of('foo'), ROBE.chain(f), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(3)])
+  })
+
+  describe('bimap', () => {
+    it('right', async () => {
+      const double = (n: number): number => n * 2
+      const doubleup = flow(double, double)
+
+      const robe = pipe(ROBE.of<unknown, number, number>(3), ROBE.bimap(doubleup, double), buffer)
+      const x = await robe({})()
+      assert.deepStrictEqual(x, [E.right(6)])
+    })
+
+    it('left', async () => {
+      const double = (n: number): number => n * 2
+      const doubleup = flow(double, double)
+
+      const robe = pipe(ROBE.throwError<unknown, number, number>(3), ROBE.bimap(doubleup, double), buffer)
+      const x = await robe({})()
+      assert.deepStrictEqual(x, [E.left(12)])
+    })
+  })
+
+  it('mapLeft', async () => {
+    const double = (n: number): number => n * 2
+    const doubleup = flow(double, double)
+
+    const robe = pipe(ROBE.throwError<unknown, number, number>(3), ROBE.mapLeft(doubleup), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.left(12)])
+  })
+
+  it('of', async () => {
+    const robe = pipe(ROBE.of('foo'), buffer)
+    const x = await robe('')()
+    assert.deepStrictEqual(x, [E.right('foo')])
+  })
+
+  it('ask', async () => {
+    const robe = pipe(ROBE.ask<string, any>(), buffer)
+    const x = await robe('foo')()
+    return assert.deepStrictEqual(x, [E.right('foo')])
+  })
+
+  it('asks', async () => {
+    const robe = pipe(
+      ROBE.asks((s: string) => s.length),
+      buffer
+    )
+    const x = await robe('foo')()
+    return assert.deepStrictEqual(x, [E.right(3)])
+  })
+
+  it('local', async () => {
+    const len = (s: string): number => s.length
+
+    const robe = pipe(
+      ROBE.asks((n: number) => n + 1),
+      ROBE.local(len),
+      buffer
+    )
+    const e = await robe('foo')()
+
+    assert.deepStrictEqual(e, [E.right(4)])
+  })
+
+  it('fromTask', async () => {
+    const robe = pipe(ROBE.fromTask(T.of(1)), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+
+  it('fromObservableEither', async () => {
+    const robe = pipe(ROBE.fromObservableEither(OBE.observableEither.of(1)), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+
+  it('fromReader', async () => {
+    const robe = pipe(ROBE.fromReader(R.of(1)), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+
+  it('fromIO', async () => {
+    const robe = pipe(ROBE.fromIO(IO.of(1)), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+
+  it('fromObservable', async () => {
+    const robe = pipe(ROBE.fromObservable(OB.of(1)), buffer)
+    const x = await robe({})()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+})

--- a/test/ReaderObservableEither.ts
+++ b/test/ReaderObservableEither.ts
@@ -6,7 +6,7 @@ import { bufferTime } from 'rxjs/operators'
 import { observable as OB, observableEither as OBE, readerObservableEither as ROBE } from '../src'
 
 // test helper to dry up LOC.
-const buffer = flow(R.map(bufferTime(10)), R.map(OB.toTask))
+export const buffer = flow(R.map(bufferTime(10)), R.map(OB.toTask))
 
 describe('ReaderObservable', () => {
   it('map', async () => {

--- a/test/StateReaderObservableEither.ts
+++ b/test/StateReaderObservableEither.ts
@@ -1,0 +1,85 @@
+import { task as T, either as E, io as IO } from 'fp-ts'
+import { stateReaderObservableEither as SROBE, observable as OB } from '../src'
+import * as assert from 'assert'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { bufferTime } from 'rxjs/operators'
+import { buffer as _buffer } from './ReaderObservableEither'
+
+function buffer<S, R, E, A>(
+  srobe: SROBE.StateReaderObservableEither<S, R, E, A>
+): (s: S) => (r: R) => T.Task<Array<E.Either<E, [A, S]>>> {
+  return s => r => pipe(srobe(s)(r), bufferTime(10), OB.toTask)
+}
+
+describe('stateReaderObservableEither', () => {
+  test('right', async () => {
+    const srobe = pipe(SROBE.right<number, number, number, number>(3), buffer)
+    const x = await srobe(1)(2)()
+
+    assert.deepStrictEqual(x, [E.right([3, 1])])
+  })
+
+  test('left', async () => {
+    const srobe = pipe(SROBE.left<number, number, number, number>(3), buffer)
+    const x = await srobe(1)(2)()
+
+    assert.deepStrictEqual(x, [E.left(3)])
+  })
+
+  test('throwError', async () => {
+    const srobe = pipe(SROBE.throwError<number, number, number, number>(3), buffer)
+    const x = await srobe(1)(2)()
+
+    assert.deepStrictEqual(x, [E.left(3)])
+  })
+
+  describe('bimap', () => {
+    const square = (a: number) => a * a
+    const doublesquare = (a: number) => a ** a
+    const bimap = SROBE.bimap(doublesquare, square)
+
+    test('map', async () => {
+      const srobe = pipe(SROBE.right<number, number, number, number>(3), bimap, buffer)
+      const x = await srobe(1)(2)()
+
+      assert.deepStrictEqual(x, [E.right([9, 1])])
+    })
+
+    test('mapLeft', async () => {
+      const srobe = pipe(SROBE.left<number, number, number, number>(3), bimap, buffer)
+      const x = await srobe(1)(2)()
+
+      assert.deepStrictEqual(x, [E.left(27)])
+    })
+  })
+
+  test('fromIO', async () => {
+    const srobe = pipe(SROBE.fromIO(IO.of(3)), buffer)
+    const x = await srobe(1)(2)()
+    assert.deepStrictEqual(x, [E.right([3, 1])])
+  })
+
+  test('fromTask', async () => {
+    const srobe = pipe(SROBE.fromTask(T.of(3)), buffer)
+    const x = await srobe(1)(2)()
+    assert.deepStrictEqual(x, [E.right([3, 1])])
+  })
+
+  test('fromObservable', async () => {
+    const srobe = pipe(SROBE.fromObservable(OB.of(3)), buffer)
+    const x = await srobe(1)(2)()
+    assert.deepStrictEqual(x, [E.right([3, 1])])
+  })
+
+  test('evaluate', async () => {
+    const srobe = pipe(SROBE.right<number, number, number, number>(3), SROBE.evaluate(1), _buffer)
+    const x = await srobe(2)()
+    assert.deepStrictEqual(x, [E.right(3)])
+  })
+
+  test('execute', async () => {
+    const srobe = pipe(SROBE.right<number, number, number, number>(3), SROBE.execute(1), _buffer)
+    const x = await srobe(2)()
+    assert.deepStrictEqual(x, [E.right(1)])
+  })
+})


### PR DESCRIPTION
ref https://github.com/gcanti/fp-ts-rxjs/issues/17#issuecomment-579755017
closes #33 

Please note I've used `pipeable` for convenience.

I've merged the two PR's and rebased the commits so they can be rebased straight in