### PR TITLE
add chainW

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-rxjs",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3172,6 +3172,7 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
+        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-rxjs",
-  "version": "0.6.11",
+  "version": "0.6.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3172,7 +3172,6 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
-        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {

--- a/src/ObservableEither.ts
+++ b/src/ObservableEither.ts
@@ -132,6 +132,14 @@ export const swap: <E, A>(ma: ObservableEither<E, A>) => ObservableEither<A, E> 
 /**
  * @since 0.6.8
  */
+export const chainW = <A, E2, B>(
+  f: (a: A) => ObservableEither<E2, B>
+) => <E1>(ma: ObservableEither<E1, A>): ObservableEither<E2 | E1, B> =>
+  T.chain(ma as any, f)
+
+/**
+ * @since 0.6.8
+ */
 export const observableEither: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> & MonadObservable2<URI> & MonadThrow2<URI> = {
   URI,
   map: T.map,

--- a/src/ReaderObservable.ts
+++ b/src/ReaderObservable.ts
@@ -138,6 +138,15 @@ export function chainIOK<A, B>(f: (a: A) => IO<B>): <R>(ma: ReaderObservable<R, 
   return chain<any, A, B>(fromIOK(f))
 }
 
+
+/**
+ * @since 0.6.8
+ */
+export const chainW = <A, R2, B>(
+  f: (a: A) => ReaderObservable<R2, B>
+) => <R1>(ma: ReaderObservable<R1, A>): ReaderObservable<R1 & R2, B> =>
+  chain(f)(ma as any) as any
+
 /**
  * @since 0.6.6
  */

--- a/src/ReaderObservableEither.ts
+++ b/src/ReaderObservableEither.ts
@@ -107,6 +107,15 @@ export function throwError<R, E, A>(e: E): ReaderObservableEither<R, E, A> {
   return () => OBE.left<E, A>(e)
 }
 
+
+/**
+ * @since 0.6.8
+ */
+export const chainW = <A, R2, E2, B>(
+  f: (a: A) => ReaderObservableEither<R2, E2, B>
+) => <R1, E1>(ma: ReaderObservableEither<R1, E2, A>): ReaderObservableEither<R1 & R2, E1 | E2, B> =>
+  chain(f)(ma as any) as any
+
 /**
  * @since 0.6.10
  */

--- a/src/StateReaderObservableEither.ts
+++ b/src/StateReaderObservableEither.ts
@@ -128,6 +128,14 @@ export function fromObservable<S, R, E, A>(observable: Observable<A>): StateRead
 }
 
 /**
+ * @since 0.6.8
+ */
+export const chainW = <A, S, R2, E2, B>(
+  f: (a: A) => StateReaderObservableEither<S, R2, E2, B>
+) => <R1, E1>(ma: StateReaderObservableEither<S, R1, E2, A>): StateReaderObservableEither<S, R1 & R2, E1 | E2, B> =>
+  chain(f)(ma as any) as any
+
+/**
  * @since 0.6.10
  */
 export const stateReaderObservableEither: MonadObservable4<URI> & Bifunctor4<URI> & MonadThrow4<URI> = {


### PR DESCRIPTION
closes https://github.com/gcanti/fp-ts-rxjs/issues/37

Based on the new [fp-ts 3.0.0 chainW signatures](https://github.com/gcanti/fp-ts/commit/f7d87917bf2fcdbc96741a2dceddd33919c564a4)

Not sure if this is desired. Ideally, `chain` would be implemented in terms of `chainW`, not the other way around. This is because the Observable* modules still use pipeable, which seems to be [on the way out](https://github.com/gcanti/fp-ts/commit/b162278ab1647a30b3cec59d1c626247048f8a2a).

Also, I didn't implement any tests for chainW, since it seems to be the convention that a test for [chain](https://github.com/gcanti/fp-ts/blob/2f21fa53bdf908c0ffa8e5e4ae1d4a882316f647/test/StateReaderTaskEither.ts#L68) is good enough

Hopefully this is a useful placeholder in lieu of a larger structural change, but I understand if we'd rather hold out.