### PR TITLE
liftOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
-# 0.6.12
+# 0.6.13
 
 - **Deprecations**
   - `Observable`

--- a/docs/modules/ObservableEither.ts.md
+++ b/docs/modules/ObservableEither.ts.md
@@ -31,6 +31,7 @@ Added in v0.6.8
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
   - [orElse](#orelse)
   - [swap](#swap)
 - [constructors](#constructors)
@@ -254,6 +255,21 @@ export declare const flatten: <E, A>(mma: ObservableEither<E, ObservableEither<E
 ```
 
 Added in v0.6.0
+
+## liftOperator
+
+Lifts an OperatorFunction into an ObservableEither context
+Allows e.g. filter to be used on on ObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ObservableEither<E, A>) => ObservableEither<E, B>
+```
+
+Added in v0.6.12
 
 ## orElse
 

--- a/docs/modules/ObservableThese.ts.md
+++ b/docs/modules/ObservableThese.ts.md
@@ -20,6 +20,7 @@ Added in v0.6.12
 - [Functor](#functor)
   - [map](#map)
 - [combinators](#combinators)
+  - [liftOperator](#liftoperator)
   - [swap](#swap)
 - [constructors](#constructors)
   - [both](#both)
@@ -102,6 +103,21 @@ export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: ObservableThese<E, A
 Added in v0.6.12
 
 # combinators
+
+## liftOperator
+
+Lifts an OperatorFunction into an ObservableThese context
+Allows e.g. filter to be used on on ObservableThese
+
+**Signature**
+
+```ts
+export declare function liftOperator<E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ObservableThese<E, A>) => ObservableThese<E, B>
+```
+
+Added in v0.6.12
 
 ## swap
 

--- a/docs/modules/ReaderObservableEither.ts.md
+++ b/docs/modules/ReaderObservableEither.ts.md
@@ -31,6 +31,7 @@ Added in v0.6.10
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
   - [local](#local)
 - [constructors](#constructors)
   - [ask](#ask)
@@ -245,6 +246,21 @@ export declare const flatten: <R, E, A>(
 ```
 
 Added in v0.6.10
+
+## liftOperator
+
+Lifts an OperatorFunction into a ReaderObservableEither context
+Allows e.g. filter to be used on on ReaderObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<R, E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ReaderObservableEither<R, E, A>) => ReaderObservableEither<R, E, B>
+```
+
+Added in v0.6.12
 
 ## local
 

--- a/docs/modules/StateReaderObservableEither.ts.md
+++ b/docs/modules/StateReaderObservableEither.ts.md
@@ -29,6 +29,7 @@ Added in v0.6.10
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
 - [constructors](#constructors)
   - [fromIO](#fromio)
   - [fromObservable](#fromobservable)
@@ -232,6 +233,21 @@ export declare const flatten: <S, R, E, A>(
 ```
 
 Added in v0.6.10
+
+## liftOperator
+
+Lifts an OperatorFunction into a StateReaderObservableEither context
+Allows e.g. filter to be used on on StateReaderObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<S, R, E, A, B>(
+  f: OperatorFunction<[A, S], [B, S]>
+): (obs: StateReaderObservableEither<S, R, E, A>) => StateReaderObservableEither<S, R, E, B>
+```
+
+Added in v0.6.12
 
 # constructors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,12 +670,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -3167,21 +3161,21 @@
       }
     },
     "import-path-rewrite": {
-      "version": "github:gcanti/import-path-rewrite#0086599732ccc761a33255a702a07266895d0572",
+      "version": "github:gcanti/import-path-rewrite#536890c96ad6bd6d347aae08958c8404b8d51e86",
       "from": "github:gcanti/import-path-rewrite",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
+        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -3231,9 +3225,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3166,7 +3166,6 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
-        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-rxjs",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "fp-ts bindings for RxJS",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/ReaderObservable.ts
+++ b/src/ReaderObservable.ts
@@ -216,6 +216,15 @@ export const chain: <R, A, B>(
   f: (a: A) => ReaderObservable<R, B>
 ) => (ma: ReaderObservable<R, A>) => ReaderObservable<R, B> = chainW
 
+
+/**
+ * @since 0.6.8
+ */
+export const chainW = <A, R2, B>(
+  f: (a: A) => ReaderObservable<R2, B>
+) => <R1>(ma: ReaderObservable<R1, A>): ReaderObservable<R1 & R2, B> =>
+  chain(f)(ma as any) as any
+
 /**
  * Derivable from `Monad`.
  *

--- a/src/ReaderObservableEither.ts
+++ b/src/ReaderObservableEither.ts
@@ -14,6 +14,7 @@ import { MonadThrow3 } from 'fp-ts/lib/MonadThrow'
 import { Option } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as R from 'fp-ts/lib/Reader'
+import { OperatorFunction } from 'rxjs'
 import { MonadObservable3 } from './MonadObservable'
 import * as OE from './ObservableEither'
 
@@ -102,6 +103,19 @@ export const fromObservable: MonadObservable3<URI>['fromObservable'] = ma => () 
 export const local: <R2, R1>(
   f: (d: R2) => R1
 ) => <E, A>(ma: ReaderObservableEither<R1, E, A>) => ReaderObservableEither<R2, E, A> = R.local
+
+/**
+ * Lifts an OperatorFunction into a ReaderObservableEither context
+ * Allows e.g. filter to be used on on ReaderObservableEither
+ *
+ * @category combinators
+ * @since 0.6.12
+ */
+export function liftOperator<R, E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ReaderObservableEither<R, E, A>) => ReaderObservableEither<R, E, B> {
+  return obs => r => OE.liftOperator<E, A, B>(f)(obs(r))
+}
 
 // -------------------------------------------------------------------------------------
 // type class members

--- a/src/ReaderObservableEither.ts
+++ b/src/ReaderObservableEither.ts
@@ -353,6 +353,15 @@ export const Applicative: Applicative3<URI> = {
   of
 }
 
+
+/**
+ * @since 0.6.8
+ */
+export const chainW = <A, R2, E2, B>(
+  f: (a: A) => ReaderObservableEither<R2, E2, B>
+) => <R1, E1>(ma: ReaderObservableEither<R1, E2, A>): ReaderObservableEither<R1 & R2, E1 | E2, B> =>
+  chain(f)(ma as any) as any
+
 /**
  * @category instances
  * @since 0.6.12

--- a/src/StateReaderObservableEither.ts
+++ b/src/StateReaderObservableEither.ts
@@ -13,8 +13,10 @@ import { MonadTask4 } from 'fp-ts/lib/MonadTask'
 import { MonadThrow4 } from 'fp-ts/lib/MonadThrow'
 import { Option } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
+import { OperatorFunction } from 'rxjs'
 import { MonadObservable4 } from './MonadObservable'
 import * as OB from './Observable'
+import * as OE from './ObservableEither'
 import * as ROE from './ReaderObservableEither'
 
 // -------------------------------------------------------------------------------------
@@ -192,6 +194,19 @@ export const apSecond = <S, R, E, B>(
     map(() => (b: B) => b),
     ap(fb)
   )
+
+/**
+ * Lifts an OperatorFunction into a StateReaderObservableEither context
+ * Allows e.g. filter to be used on on StateReaderObservableEither
+ *
+ * @category combinators
+ * @since 0.6.12
+ */
+export function liftOperator<S, R, E, A, B>(
+  f: OperatorFunction<[A, S], [B, S]>
+): (obs: StateReaderObservableEither<S, R, E, A>) => StateReaderObservableEither<S, R, E, B> {
+  return obs => s => r => OE.liftOperator<E, [A, S], [B, S]>(f)(obs(s)(r))
+}
 
 /**
  * @category Bifunctor

--- a/test/ObservableEither.ts
+++ b/test/ObservableEither.ts
@@ -7,7 +7,8 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { bufferTime } from 'rxjs/operators'
 import * as O from 'fp-ts/lib/Option'
 import * as _ from '../src/ObservableEither'
-import { of as rxOf, Observable, throwError as rxThrowError } from 'rxjs'
+import { of as rxOf, Observable, from, throwError as rxThrowError } from 'rxjs'
+import { filter } from '../src/Observable'
 
 describe('ObservableEither', () => {
   it('rightIO', async () => {
@@ -123,6 +124,20 @@ describe('ObservableEither', () => {
       .pipe(bufferTime(10))
       .toPromise()
     assert.deepStrictEqual(e, [E.left(1)])
+  })
+
+  it('liftOperator (left)', async () => {
+    const e = await pipe(from(['error1', 'error2']), _.leftObservable, _.liftOperator(filter(x => x % 2 === 0)))
+      .pipe(bufferTime(10))
+      .toPromise()
+    assert.deepStrictEqual(e, [E.left('error1'), E.left('error2')])
+  })
+
+  it('liftOperator (right)', async () => {
+    const e = await pipe(from([1, 2, 3, 4]), _.rightObservable, _.liftOperator(filter(x => x % 2 === 0)))
+      .pipe(bufferTime(10))
+      .toPromise()
+    assert.deepStrictEqual(e, [E.right(2), E.right(4)])
   })
 
   describe('Monad', () => {


### PR DESCRIPTION
Closes https://github.com/gcanti/fp-ts-rxjs/issues/39 (allows `OperatorFunctions` e.g. `filter` to be used on `ObservableEither`, `ObservableThese`, `ReaderObservableEither` and `StateReaderObservableEither`)

Version of https://github.com/gcanti/fp-ts-rxjs/pull/42, branched from 0.6.12

[Edit: added `ObservableThese`]