### PR TITLE
liftOperator

### DIFF
--- a/docs/modules/ObservableEither.ts.md
+++ b/docs/modules/ObservableEither.ts.md
@@ -31,6 +31,7 @@ Added in v0.6.8
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
   - [orElse](#orelse)
   - [swap](#swap)
 - [constructors](#constructors)
@@ -254,6 +255,21 @@ export declare const flatten: <E, A>(mma: ObservableEither<E, ObservableEither<E
 ```
 
 Added in v0.6.0
+
+## liftOperator
+
+Lifts an OperatorFunction into an ObservableEither context
+Allows e.g. filter to be used on on ObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ObservableEither<E, A>) => ObservableEither<E, B>
+```
+
+Added in v0.6.12
 
 ## orElse
 

--- a/docs/modules/ObservableThese.ts.md
+++ b/docs/modules/ObservableThese.ts.md
@@ -20,6 +20,7 @@ Added in v0.6.12
 - [Functor](#functor)
   - [map](#map)
 - [combinators](#combinators)
+  - [liftOperator](#liftoperator)
   - [swap](#swap)
 - [constructors](#constructors)
   - [both](#both)
@@ -102,6 +103,21 @@ export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: ObservableThese<E, A
 Added in v0.6.12
 
 # combinators
+
+## liftOperator
+
+Lifts an OperatorFunction into an ObservableThese context
+Allows e.g. filter to be used on on ObservableThese
+
+**Signature**
+
+```ts
+export declare function liftOperator<E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ObservableThese<E, A>) => ObservableThese<E, B>
+```
+
+Added in v0.6.12
 
 ## swap
 

--- a/docs/modules/ReaderObservableEither.ts.md
+++ b/docs/modules/ReaderObservableEither.ts.md
@@ -31,6 +31,7 @@ Added in v0.6.10
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
   - [local](#local)
 - [constructors](#constructors)
   - [ask](#ask)
@@ -245,6 +246,21 @@ export declare const flatten: <R, E, A>(
 ```
 
 Added in v0.6.10
+
+## liftOperator
+
+Lifts an OperatorFunction into a ReaderObservableEither context
+Allows e.g. filter to be used on on ReaderObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<R, E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ReaderObservableEither<R, E, A>) => ReaderObservableEither<R, E, B>
+```
+
+Added in v0.6.12
 
 ## local
 

--- a/docs/modules/StateReaderObservableEither.ts.md
+++ b/docs/modules/StateReaderObservableEither.ts.md
@@ -29,6 +29,7 @@ Added in v0.6.10
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [flatten](#flatten)
+  - [liftOperator](#liftoperator)
 - [constructors](#constructors)
   - [fromIO](#fromio)
   - [fromObservable](#fromobservable)
@@ -232,6 +233,21 @@ export declare const flatten: <S, R, E, A>(
 ```
 
 Added in v0.6.10
+
+## liftOperator
+
+Lifts an OperatorFunction into a StateReaderObservableEither context
+Allows e.g. filter to be used on on StateReaderObservableEither
+
+**Signature**
+
+```ts
+export declare function liftOperator<S, R, E, A, B>(
+  f: OperatorFunction<[A, S], [B, S]>
+): (obs: StateReaderObservableEither<S, R, E, A>) => StateReaderObservableEither<S, R, E, B>
+```
+
+Added in v0.6.12
 
 # constructors
 

--- a/src/ReaderObservableEither.ts
+++ b/src/ReaderObservableEither.ts
@@ -14,6 +14,7 @@ import { MonadThrow3 } from 'fp-ts/lib/MonadThrow'
 import { Option } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as R from 'fp-ts/lib/Reader'
+import { OperatorFunction } from 'rxjs'
 import { MonadObservable3 } from './MonadObservable'
 import * as OE from './ObservableEither'
 
@@ -102,6 +103,19 @@ export const fromObservable: MonadObservable3<URI>['fromObservable'] = ma => () 
 export const local: <R2, R1>(
   f: (d: R2) => R1
 ) => <E, A>(ma: ReaderObservableEither<R1, E, A>) => ReaderObservableEither<R2, E, A> = R.local
+
+/**
+ * Lifts an OperatorFunction into a ReaderObservableEither context
+ * Allows e.g. filter to be used on on ReaderObservableEither
+ *
+ * @category combinators
+ * @since 0.6.12
+ */
+export function liftOperator<R, E, A, B>(
+  f: OperatorFunction<A, B>
+): (obs: ReaderObservableEither<R, E, A>) => ReaderObservableEither<R, E, B> {
+  return obs => r => OE.liftOperator<E, A, B>(f)(obs(r))
+}
 
 // -------------------------------------------------------------------------------------
 // type class members

--- a/src/StateReaderObservableEither.ts
+++ b/src/StateReaderObservableEither.ts
@@ -13,8 +13,10 @@ import { MonadTask4 } from 'fp-ts/lib/MonadTask'
 import { MonadThrow4 } from 'fp-ts/lib/MonadThrow'
 import { Option } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
+import { OperatorFunction } from 'rxjs'
 import { MonadObservable4 } from './MonadObservable'
 import * as OB from './Observable'
+import * as OE from './ObservableEither'
 import * as ROE from './ReaderObservableEither'
 
 // -------------------------------------------------------------------------------------
@@ -192,6 +194,19 @@ export const apSecond = <S, R, E, B>(
     map(() => (b: B) => b),
     ap(fb)
   )
+
+/**
+ * Lifts an OperatorFunction into a StateReaderObservableEither context
+ * Allows e.g. filter to be used on on StateReaderObservableEither
+ *
+ * @category combinators
+ * @since 0.6.12
+ */
+export function liftOperator<S, R, E, A, B>(
+  f: OperatorFunction<[A, S], [B, S]>
+): (obs: StateReaderObservableEither<S, R, E, A>) => StateReaderObservableEither<S, R, E, B> {
+  return obs => s => r => OE.liftOperator<E, [A, S], [B, S]>(f)(obs(s)(r))
+}
 
 /**
  * @category Bifunctor

--- a/test/ObservableEither.ts
+++ b/test/ObservableEither.ts
@@ -7,7 +7,8 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import { bufferTime } from 'rxjs/operators'
 import * as O from 'fp-ts/lib/Option'
 import * as _ from '../src/ObservableEither'
-import { of as rxOf, Observable, throwError as rxThrowError } from 'rxjs'
+import { of as rxOf, Observable, from, throwError as rxThrowError } from 'rxjs'
+import { filter } from '../src/Observable'
 
 describe('ObservableEither', () => {
   it('rightIO', async () => {
@@ -123,6 +124,20 @@ describe('ObservableEither', () => {
       .pipe(bufferTime(10))
       .toPromise()
     assert.deepStrictEqual(e, [E.left(1)])
+  })
+
+  it('liftOperator (left)', async () => {
+    const e = await pipe(from(['error1', 'error2']), _.leftObservable, _.liftOperator(filter(x => x % 2 === 0)))
+      .pipe(bufferTime(10))
+      .toPromise()
+    assert.deepStrictEqual(e, [E.left('error1'), E.left('error2')])
+  })
+
+  it('liftOperator (right)', async () => {
+    const e = await pipe(from([1, 2, 3, 4]), _.rightObservable, _.liftOperator(filter(x => x % 2 === 0)))
+      .pipe(bufferTime(10))
+      .toPromise()
+    assert.deepStrictEqual(e, [E.right(2), E.right(4)])
   })
 
   describe('Monad', () => {


### PR DESCRIPTION
Closes https://github.com/gcanti/fp-ts-rxjs/issues/39 (allows OperatorFunctions e.g. filter to be used on ObservableEither, ObservableThese, ReaderObservableEither and StateReaderObservableEither)

Version of https://github.com/gcanti/fp-ts-rxjs/pull/47, branched from master