### PR TITLE
doc typo: Aletrnaitve -> Alternative

### DIFF
--- a/docs/modules/Observable.ts.md
+++ b/docs/modules/Observable.ts.md
@@ -12,7 +12,7 @@ Added in v0.6.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [Aletrnaitve](#aletrnaitve)
+- [Alternative](#alternative)
   - [zero](#zero)
 - [Alt](#alt)
   - [alt](#alt)
@@ -65,7 +65,7 @@ Added in v0.6.0
 
 ---
 
-# Aletrnaitve
+# Alternative
 
 ## zero
 

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -213,7 +213,7 @@ export const partition: {
 } = <A>(p: Predicate<A>) => (fa: Observable<A>) => pipe(fa, partitionMap(E.fromPredicate(p, identity)))
 
 /**
- * @category Aletrnaitve
+ * @category Alternative
  * @since 0.6.12
  */
 export const zero: Alternative1<URI>['zero'] = () => EMPTY


### PR DESCRIPTION
This PR fixes a typo in the Observable documentation: Aletrnaitve -> Alternative